### PR TITLE
Made it possible to get phase

### DIFF
--- a/parametric-eq/src/eq_core/eq.rs
+++ b/parametric-eq/src/eq_core/eq.rs
@@ -10,7 +10,7 @@ use num_complex::Complex;
 use crate::FILTER_POLE_COUNT;
 
 use super::{
-    svf::{SVFCoefficients, Type, SVF},
+    svf::{SVFCoefficients, Type, ZSample, SVF},
     units::{butterworth_cascade_q, Units},
 };
 
@@ -85,12 +85,12 @@ impl SVFCoefficientsSet {
         }
     }
 
-    pub fn get_bode_sample(&self, f_hz: f64) -> Complex<f64> {
-        //Use y.norm() for amplitude and -y.arg().to_degrees() for phase. Add to combine phase.
-        let mut y = self.a[0].get_bode_sample(f_hz) * self.b[0].get_bode_sample(f_hz);
+    pub fn get_bode_sample(&self, z: ZSample) -> Complex<f64> {
+        //Use y.norm() for amplitude and y.arg().to_degrees() for phase. Add to combine phase.
+        let mut y = self.a[0].get_bode_sample(z) * self.b[0].get_bode_sample(z);
         for (band_a, band_b) in self.a.iter().skip(1).zip(self.b.iter().skip(1)) {
-            y *= band_a.get_bode_sample(f_hz);
-            y *= band_b.get_bode_sample(f_hz);
+            y *= band_a.get_bode_sample(z);
+            y *= band_b.get_bode_sample(z);
         }
         y
     }
@@ -129,9 +129,9 @@ impl FilterbandStereo {
         }
     }
 
-    pub fn get_bode_sample(&self, f_hz: f64) -> Complex<f64> {
-        //Use y.norm() for amplitude and -y.arg().to_degrees() for phase. Add to combine phase.
-        let mut y = self.coeffs.get_bode_sample(f_hz);
+    pub fn get_bode_sample(&self, z: ZSample) -> Complex<f64> {
+        //Use y.norm() for amplitude and y.arg().to_degrees() for phase. Add to combine phase.
+        let mut y = self.coeffs.get_bode_sample(z);
         if self.kind == FilterKind::Mesa {
             let gain = self.gain.db_to_lin();
             y *= gain;

--- a/parametric-eq/src/eq_core/eq.rs
+++ b/parametric-eq/src/eq_core/eq.rs
@@ -5,6 +5,8 @@ use core::fmt;
 //    units::{butterworth_cascade_q, Units},
 //};
 
+use num_complex::Complex;
+
 use crate::FILTER_POLE_COUNT;
 
 use super::{
@@ -83,11 +85,12 @@ impl SVFCoefficientsSet {
         }
     }
 
-    pub fn get_amplitude(&self, f_hz: f64) -> f64 {
-        let mut y = 1.0f64;
-        for (band_a, band_b) in self.a.iter().zip(self.b.iter()) {
-            y *= band_a.get_amplitude(f_hz);
-            y *= band_b.get_amplitude(f_hz);
+    pub fn get_bode_sample(&self, f_hz: f64) -> Complex<f64> {
+        //Use y.norm() for amplitude and -y.arg().to_degrees() for phase. Add to combine phase.
+        let mut y = self.a[0].get_bode_sample(f_hz) * self.b[0].get_bode_sample(f_hz);
+        for (band_a, band_b) in self.a.iter().skip(1).zip(self.b.iter().skip(1)) {
+            y *= band_a.get_bode_sample(f_hz);
+            y *= band_b.get_bode_sample(f_hz);
         }
         y
     }
@@ -126,8 +129,9 @@ impl FilterbandStereo {
         }
     }
 
-    pub fn get_amplitude(&self, f_hz: f64) -> f64 {
-        let mut y = self.coeffs.get_amplitude(f_hz);
+    pub fn get_bode_sample(&self, f_hz: f64) -> Complex<f64> {
+        //Use y.norm() for amplitude and -y.arg().to_degrees() for phase. Add to combine phase.
+        let mut y = self.coeffs.get_bode_sample(f_hz);
         if self.kind == FilterKind::Mesa {
             let gain = self.gain.db_to_lin();
             y *= gain;

--- a/parametric-eq/src/eq_core/svf.rs
+++ b/parametric-eq/src/eq_core/svf.rs
@@ -35,8 +35,8 @@ pub struct SVFCoefficients<T> {
 }
 
 impl SVFCoefficients<f64> {
-    pub fn get_amplitude(self, f_hz: f64) -> f64 {
-        //TODO gain up MESA
+    pub fn get_bode_sample(self, f_hz: f64) -> Complex<f64> {
+        //Use y.norm() for amplitude and -y.arg().to_degrees() for phase. Add to combine phase.
         let imag = Complex::new(0.0, 1.0);
 
         let z = (-TAU * f_hz * imag / self.fs).exp();
@@ -53,7 +53,7 @@ impl SVFCoefficients<f64> {
             + (self.m1 * self.g * (1.0 - z_n2) + self.m2 * gpow2 * (1.0 + 2.0 * z_n1 + z_n2))
                 / denominator;
 
-        return y.norm();
+        y
     }
 
     /// Creates a SVF from a set of filter coefficients

--- a/parametric-eq/src/eq_core/svf.rs
+++ b/parametric-eq/src/eq_core/svf.rs
@@ -21,9 +21,27 @@ pub enum Type<DBGain> {
 }
 
 #[derive(Copy, Clone, Debug)]
+pub struct ZSample {
+    pow1: Complex<f64>,
+    pow2: Complex<f64>,
+}
+
+impl ZSample {
+    pub fn new(f_hz: f64, fs: f64) -> ZSample {
+        let z = -TAU * f_hz / fs;
+        let z = z.cos() + z.sin() * Complex::new(0.0, 1.0);
+        ZSample {
+            pow1: z,
+            pow2: z * z,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
 pub struct SVFCoefficients<T> {
     pub a: T,
     pub g: T,
+    pub gpow2: T,
     pub k: T,
     pub a1: T,
     pub a2: T,
@@ -35,22 +53,16 @@ pub struct SVFCoefficients<T> {
 }
 
 impl SVFCoefficients<f64> {
-    pub fn get_bode_sample(self, f_hz: f64) -> Complex<f64> {
-        //Use y.norm() for amplitude and -y.arg().to_degrees() for phase. Add to combine phase.
-        let imag = Complex::new(0.0, 1.0);
+    pub fn get_bode_sample(self, z: ZSample) -> Complex<f64> {
+        //Use y.norm() for amplitude and y.arg().to_degrees() for phase. Add to combine phase.
 
-        let z = (-TAU * f_hz * imag / self.fs).exp();
-
-        let gpow2 = self.g.powf(2.0);
-        let z_n1 = z.powf(-1.0);
-        let z_n2 = z.powf(-2.0);
-
-        let denominator = (gpow2 + self.g * self.k + 1.0)
-            + 2.0 * (gpow2 - 1.0) * z_n1
-            + (gpow2 - self.g * self.k + 1.0) * z_n2;
+        let denominator = (self.gpow2 + self.g * self.k + 1.0)
+            + 2.0 * (self.gpow2 - 1.0) * z.pow1
+            + (self.gpow2 - self.g * self.k + 1.0) * z.pow2;
 
         let y = self.m0
-            + (self.m1 * self.g * (1.0 - z_n2) + self.m2 * gpow2 * (1.0 + 2.0 * z_n1 + z_n2))
+            + (self.m1 * self.g * (1.0 - z.pow2)
+                + self.m2 * self.gpow2 * (1.0 + 2.0 * z.pow1 + z.pow2))
                 / denominator;
 
         y
@@ -85,6 +97,7 @@ impl SVFCoefficients<f64> {
                 Ok(SVFCoefficients {
                     a,
                     g,
+                    gpow2: g * g,
                     k,
                     a1,
                     a2,
@@ -108,6 +121,7 @@ impl SVFCoefficients<f64> {
                 Ok(SVFCoefficients {
                     a,
                     g,
+                    gpow2: g * g,
                     k,
                     a1,
                     a2,
@@ -131,6 +145,7 @@ impl SVFCoefficients<f64> {
                 Ok(SVFCoefficients {
                     a,
                     g,
+                    gpow2: g * g,
                     k,
                     a1,
                     a2,
@@ -154,6 +169,7 @@ impl SVFCoefficients<f64> {
                 Ok(SVFCoefficients {
                     a,
                     g,
+                    gpow2: g * g,
                     k,
                     a1,
                     a2,
@@ -177,6 +193,7 @@ impl SVFCoefficients<f64> {
                 Ok(SVFCoefficients {
                     a,
                     g,
+                    gpow2: g * g,
                     k,
                     a1,
                     a2,
@@ -200,6 +217,7 @@ impl SVFCoefficients<f64> {
                 Ok(SVFCoefficients {
                     a,
                     g,
+                    gpow2: g * g,
                     k,
                     a1,
                     a2,
@@ -223,6 +241,7 @@ impl SVFCoefficients<f64> {
                 Ok(SVFCoefficients {
                     a,
                     g,
+                    gpow2: g * g,
                     k,
                     a1,
                     a2,
@@ -246,6 +265,7 @@ impl SVFCoefficients<f64> {
                 Ok(SVFCoefficients {
                     a,
                     g,
+                    gpow2: g * g,
                     k,
                     a1,
                     a2,

--- a/parametric-eq/src/ui/graph.rs
+++ b/parametric-eq/src/ui/graph.rs
@@ -10,7 +10,7 @@ use rustfft::{Fft, FftPlanner, num_complex::Complex, num_traits::real};
 use std::{cell::UnsafeCell, sync::Arc};
 use std::cmp::Ordering;
 
-use crate::eq_core::svf::{Type, SVFCoefficients};
+use crate::eq_core::svf::{Type, SVFCoefficients, ZSample};
 
 use super::super::util::lpsd::lpsd;
 
@@ -461,9 +461,10 @@ impl Widget for Graph {
 
         for i in 0..720 {
             let freq = index_to_freq(i as f32, min, max, 720.0);
-            let amp0 = self.filters[0].get_bode_sample(freq as f64).norm() as f32;
-            let amp1 = self.filters[1].get_bode_sample(freq as f64).norm() as f32;
-            let amp2 = self.filters[2].get_bode_sample(freq as f64).norm() as f32;
+            let z = ZSample::new(freq as f64, 44100.0); //TODO get actual sample rate
+            let amp0 = self.filters[0].get_bode_sample(z).norm() as f32;
+            let amp1 = self.filters[1].get_bode_sample(z).norm() as f32;
+            let amp2 = self.filters[2].get_bode_sample(z).norm() as f32;
 
             let amp = amp0 * amp1 * amp2;
             

--- a/parametric-eq/src/ui/graph.rs
+++ b/parametric-eq/src/ui/graph.rs
@@ -461,11 +461,11 @@ impl Widget for Graph {
 
         for i in 0..720 {
             let freq = index_to_freq(i as f32, min, max, 720.0);
-            let amp0 = self.filters[0].get_amplitude(freq as f64) as f32;
-            let amp1 = self.filters[1].get_amplitude(freq as f64) as f32;
-            let amp2 = self.filters[2].get_amplitude(freq as f64) as f32;
+            let amp0 = self.filters[0].get_bode_sample(freq as f64).norm() as f32;
+            let amp1 = self.filters[1].get_bode_sample(freq as f64).norm() as f32;
+            let amp2 = self.filters[2].get_bode_sample(freq as f64).norm() as f32;
 
-            let amp = (amp0 * amp1 * amp2);
+            let amp = amp0 * amp1 * amp2;
             
             let amp_db = 20.0 * amp.log10().max(-12.0) / 12.0;
             if i == 0 {


### PR DESCRIPTION
Changed `get_amplitude` to `get_bode_sample`. get_bode_sample returns a complex number.

Use y.norm() for amplitude and -y.arg().to_degrees() for phase. 

Add to combine phase.

I updated the ui graph to use this new method for amplitude.